### PR TITLE
Add login button; limit visibility of some features

### DIFF
--- a/bhr/browser_views.py
+++ b/bhr/browser_views.py
@@ -129,3 +129,12 @@ class SourceListView(TemplateView):
             'source': source,
             'blocks': query_to_blocklist(blocks),
         }
+
+def login(request):
+    '''Provides a authentication method agnostic login view.
+
+    This gives us something to point to in the templates without requiring us
+    to know exactly which authentication method is being used.
+    '''
+
+    return redirect(settings.LOGIN_URL)

--- a/bhr/templates/base.html
+++ b/bhr/templates/base.html
@@ -43,16 +43,24 @@
           <ul class="nav navbar-nav">
             <li class="active"><a href="{% url 'home' %}">Home</a></li>
 
+            {% if perms.bhr.add_block %}
             <li><a href="{% url 'add' %}">Add Block</a></li>
+            {% endif %}
             <li><a href="{% url 'query' %}">Query</a></li>
             <li><a href="{% url 'stats' %}">Stats</a></li>
             <li><a href="{% url 'list' %}">Block list</a></li>
           </ul>
-          {% if user.is_authenticated %}
           <ul class="nav navbar-nav navbar-right">
-            <li> <a href="{% url "django.contrib.auth.views.logout" %}">Log Out</a> </li>
-          </ul>
+          {% if user.is_authenticated %}
+            <li>
+              <div class="navbar-text">
+                <span class="glyphicon glyphicon-user" aria-hidden="true" ></span> {{ user.username }}
+              </div>
+            <li><a href="{% url "django.contrib.auth.views.logout" %}?next={% url 'home' %}">Log Out</a></li>
+          {% else %}
+            <li><a href="{% url 'login' %}">Login</a></li>
           {% endif %}
+          </ul>
         </div><!--/.nav-collapse -->
       </div>
     </div>

--- a/bhr/templates/bhr/index.html
+++ b/bhr/templates/bhr/index.html
@@ -5,7 +5,9 @@
 <h2>Pages</h2>
 
 <ul>
+    {% if perms.bhr.add_block %}
     <li><a href="{% url 'add' %}">Add Block</a></li>
+    {% endif %}
     <li><a href="{% url 'query' %}">Query</a></li>
     <li><a href="{% url 'stats' %}">Stats</a></li>
     <li><a href="{% url 'list' %}">Block list</a></li>

--- a/bhr/urls.py
+++ b/bhr/urls.py
@@ -35,14 +35,17 @@ urlpatterns = [
     url(r'^api/query/(?P<cidr>.+)', views.BlockHistory.as_view()),
 
     url('^$', browser_views.IndexView.as_view(), name="home"),
-    url('^add$', permission_required('bhr.add_block')(browser_views.AddView.as_view()), name="add"),
+    url('^add$', permission_required('bhr.add_block', raise_exception=True)(browser_views.AddView.as_view()), name="add"),
     url('^query$', login_required(browser_views.QueryView.as_view()), name="query"),
-    url('^unblock$', permission_required('bhr.change_block')(browser_views.UnblockView.as_view()), name="unblock"),
-    url('^do_unblock$', permission_required('bhr.change_block')(browser_views.DoUnblockView.as_view()), name="do_unblock"),
+    url('^unblock$', permission_required('bhr.change_block', raise_exception=True)(browser_views.UnblockView.as_view()), name="unblock"),
+    url('^do_unblock$', permission_required('bhr.change_block', raise_exception=True)(browser_views.DoUnblockView.as_view()), name="do_unblock"),
     url(r'^stats$', browser_views.StatsView.as_view(), name="stats"),
     url(r'^list$', login_required(browser_views.ListView.as_view()), name="list"),
     url(r'^list/source/(?P<source>.+)$', login_required(browser_views.SourceListView.as_view()), name="source-list"),
     url(r'^list.csv', views.bhlist.as_view(), name='csv'),
+
+    # auth mechanism agnostic login
+    url(r'^login$', browser_views.login, name='login'),
 ]
 
 if settings.BHR.get('unauthenticated_limited_query', False):

--- a/bhr_site/settings.py
+++ b/bhr_site/settings.py
@@ -130,6 +130,9 @@ LOGGING = {
     }
 }
 
+# Where to go after authenticating if, next isn't specified
+LOGIN_REDIRECT_URL = '/'
+
 BHR = {
     'time_multiplier':              2.0,
     'time_window_factor':           2.0,


### PR DESCRIPTION
* Add a login link to the site header
* Only show 'Add block' link if the user has permission to add blocks
* Raise an exception of user tries to access view they do not have
  permissions for
* Add a generic login view that allows the templates to refer to the
  login view without knowing the exact login method being used. This
  allows using other login methods (such as Shibboleth) by overriding
  the default LOGIN_URL setting.
* Sets LOGIN_REDIRECT_URL to / since there is no profile page.

This was a collaboration @samoehlert as part of integrating the bhr into ESnet's environment. 