### PR TITLE
Change Login Name to Prevent Conflict

### DIFF
--- a/bhr_site/urls.py
+++ b/bhr_site/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
 
     url(r'^admin/', include(admin.site.urls)),
     url(r'^bhr/', include('bhr.urls')),
-    url(r'^accounts/login/$', auth_views.login, {'template_name': 'login.html'}, name='login'),
+    url(r'^accounts/login/$', auth_views.login, {'template_name': 'login.html'}, name='accounts_login'),
     url(r'^accounts/logout/$', auth_views.logout, name='logout'),
 
     url(r'^$', RedirectView.as_view(url='/bhr', permanent=False), name='siteroot'),


### PR DESCRIPTION
There were multiple places in the urls.py files with the name='login' which caused us issues using our SSO. The login button on the top right would point to /accounts/login, which was not the login_url set in settings_local.py